### PR TITLE
Add Other resources section

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,15 @@
             </li>
 
         </ul>
+<h2>Other</h2>
+        <ul class="section-list">
+            <li class="section-item">
+                <a href="other/README.html">
+                    <strong>Other — дополнительные материалы</strong>
+                </a>
+            </li>
+
+        </ul>
 </div>
 </body>
 </html>

--- a/other/README.html
+++ b/other/README.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Other — дополнительные материалы</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <div class="container">
+<h3>Other — дополнительные материалы</h3>
+        <ul class="section-list">
+            <li class="section-item">
+                <a href="sites.html">
+                    <strong>1. Веб-сайты и онлайн-материалы</strong>
+                </a>
+            </li>
+            <li class="section-item">
+                <a href="apps.html">
+                    <strong>2. Приложения</strong>
+                </a>
+            </li>
+            <li class="section-item">
+                <a href="youtube.html">
+                    <strong>3. YouTube-каналы и видео/плейлисты</strong>
+                </a>
+            </li>
+        </ul>
+        <div class="back-link">
+            <a href="../index.html">Back</a>
+        </div>
+
+    </div>
+</body>
+</html>

--- a/other/apps.html
+++ b/other/apps.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Приложения</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <div class="container">
+        <h3>Приложения</h3>
+        <ul class="resource-list">
+            <li class="resource-item">
+                <strong>BoldVoice App</strong>
+                <p>Бесплатная оценка и 7 дней уроков с видео от голливудских коучей.</p>
+                <a href="https://www.boldvoice.com/">boldvoice.com</a>
+            </li>
+            <li class="resource-item">
+                <strong>Speechling App</strong>
+                <p>Бесплатная запись и обратная связь от коучей, тысячи фраз для практики.</p>
+                <a href="https://speechling.com/">speechling.com</a>
+            </li>
+            <li class="resource-item">
+                <strong>Gliglish App</strong>
+                <p>Бесплатно 10 минут в день разговоров с AI и фидбеком по произношению.</p>
+                <a href="https://gliglish.com/">gliglish.com</a>
+            </li>
+            <li class="resource-item">
+                <strong>HelloTalk</strong>
+                <p>Бесплатный обмен языками — чат и голосовые комнаты с носителями. Получайте корректировки произношения в реальном времени.</p>
+                <a href="https://hellotalk.com">hellotalk.com</a>
+            </li>
+        </ul>
+        <div class="back-link">
+            <a href="README.html">Back</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/other/sites.html
+++ b/other/sites.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Веб-сайты и онлайн-материалы</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <div class="container">
+        <h3>Веб-сайты и онлайн-материалы</h3>
+        <ul class="resource-list">
+            <li class="resource-item">
+                <strong>SpeechActive</strong>
+                <p>Бесплатный стартовый курс по произношению с фокусом на трудности русских. Инструмент для записи и сравнения звуков.</p>
+                <a href="https://www.speechactive.com/english-pronunciation-accent-reduction-russian/">курс</a>,
+                <a href="https://www.speechactive.com/listen-english-vowels-and-consonant-sounds/">рекордер</a>
+            </li>
+            <li class="resource-item">
+                <strong>BoldVoice</strong>
+                <p>Блог с советами по типичным трудностям русских. Бесплатная оценка акцента и 7-дневный trial в приложении.</p>
+                <a href="https://www.boldvoice.com/blog/english-pronunciation-russian-speakers">blog</a>,
+                <a href="https://www.boldvoice.com/">оценка</a>
+            </li>
+            <li class="resource-item">
+                <strong>YouGlish</strong>
+                <p>Бесплатный инструмент для прослушивания реального произношения слов и фраз в контексте.</p>
+                <a href="https://youglish.com/">youglish.com</a>
+            </li>
+            <li class="resource-item">
+                <strong>Speechling</strong>
+                <p>Бесплатная практика с записью предложений и обратной связью от коучей.</p>
+                <a href="https://speechling.com/">speechling.com</a>
+            </li>
+            <li class="resource-item">
+                <strong>Gliglish</strong>
+                <p>Бесплатные 10 минут в день разговоров с AI и обратной связью по произношению.</p>
+                <a href="https://gliglish.com/">gliglish.com</a>
+            </li>
+            <li class="resource-item">
+                <em>Сайты для прослушивания акцентов</em>
+            </li>
+            <li class="resource-item">
+                <strong>International Dialects of English Archive</strong>
+                <p>Бесплатные записи носителей, чтение текстов.</p>
+                <a href="http://www.dialectsarchive.com/">dialectsarchive.com</a>
+            </li>
+            <li class="resource-item">
+                <strong>Speech Accent Archive</strong>
+                <p>Фразы в разных акцентах, включая non-native.</p>
+                <a href="http://accent.gmu.edu/">accent.gmu.edu</a>
+            </li>
+            <li class="resource-item">
+                <strong>LibriVox</strong>
+                <p>Бесплатные аудиокниги с разными акцентами для практики.</p>
+                <a href="https://librivox.org/">librivox.org</a>
+            </li>
+        </ul>
+        <div class="back-link">
+            <a href="README.html">Back</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/other/youtube.html
+++ b/other/youtube.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>YouTube-каналы и видео</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <div class="container">
+        <h3>YouTube-каналы и видео</h3>
+        <ul class="resource-list">
+            <li class="resource-item">
+                <strong>English Pronunciation Course For Russian Speakers</strong>
+                <p>Плейлист из 11 видео.</p>
+                <a href="https://www.youtube.com/playlist?list=PLi2YtixXXV8wtN5LQDInqhqiK76v0eh3w">ссылка</a>
+            </li>
+            <li class="resource-item">
+                <strong>Free English Help for Ukrainian and Russian Speakers</strong>
+                <p>Уроки по произношению для славянских носителей.</p>
+                <a href="https://www.youtube.com/watch?v=QkUAloBbByM">видео</a>
+            </li>
+            <li class="resource-item">
+                <strong>American Accent Training for RUSSIAN Speakers</strong>
+                <p>Советы по американскому акценту.</p>
+                <a href="https://www.youtube.com/watch?v=yKRiCmGIMVw">видео</a>
+            </li>
+            <li class="resource-item">
+                <strong>10 pronunciation mistakes RUSSIAN SPEAKERS make</strong>
+                <p>Анализ типичных ошибок и упражнения.</p>
+                <a href="https://www.youtube.com/watch?v=ZPPBQcz-ZPk">видео</a>
+            </li>
+            <li class="resource-item">
+                <strong>How to Speak English - Pronunciation for Russian Speakers</strong>
+                <p>Урок по естественному произношению.</p>
+                <a href="https://www.youtube.com/watch?v=g3L21HDRt5A">видео</a>
+            </li>
+        </ul>
+        <div class="back-link">
+            <a href="README.html">Back</a>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add link to new Other section on the homepage
- provide Other landing page with subpages
- include resource lists for sites, apps and YouTube playlists
- style resource subpages using `resource-item`

## Testing
- `python -m py_compile apply_template.py`


------
https://chatgpt.com/codex/tasks/task_e_68885b0ff8948325a8ffa9dfd28c8d15